### PR TITLE
fix: support multi arch image building

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -26,6 +26,12 @@ jobs:
         codename: [ beige ]
 
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Read Rootfs version
         run: |
           echo "ROOTFS_VERSION=$(curl -s https://raw.githubusercontent.com/deepin-community/deepin-rootfs/master/version.txt | cat)" >> $GITHUB_ENV

--- a/build.sh
+++ b/build.sh
@@ -12,4 +12,4 @@ ROOTFS_URL=https://github.com/deepin-community/deepin-rootfs/releases/download/$
 
 curl -OLS $ROOTFS_URL
 
-docker build --build-arg ROOTFS=$ROOTFS -t ${OWNER}/deepin:${CODENAME}-${ARCH}-${VERSION} .
+docker buildx build --platform linux/${ARCH} --build-arg ROOTFS=$ROOTFS -t ${OWNER}/deepin:${CODENAME}-${ARCH}-${VERSION} .


### PR DESCRIPTION
当前的镜像构建时，使用的 runner 是 x86_64 且没有对其他架构镜像的 manifest 进行修改，因此在 Docker Hub 上没有显示多个架构。

该 PR 进行了以下修改：
- 在 Runner 中设置 Qemu 环境
- 使用 DockerX 为每个架构的镜像，使用对应架构的 Builder 进行构建

参考：
- [构建成功的 GitHub Action（在我的分支上，修改了 OWNER）](https://github.com/jingfelix/fix-deepin-docker/actions/runs/8874182154)
- [构建成功的 Docker 镜像（使用了我自己的账户和namespace）](https://hub.docker.com/r/jingfelix/deepin/tags)

在龙芯3A6000 上运行的截图：
<img width="443" alt="截屏2024-04-08 16 48 10" src="https://github.com/deepin-community/deepin-docker/assets/72600955/817f0996-24a8-4beb-81cc-d0ff2e575820">
